### PR TITLE
Fix inline code snippet link style

### DIFF
--- a/commons/styles.css
+++ b/commons/styles.css
@@ -242,7 +242,7 @@ th {
     display: inline-block;
     font-family: 'Source Code Pro', monospace;
     color: inherit;
-    padding: 0 .3em;
+    margin: 0;
 }
 
 .markdown-section pre {


### PR DESCRIPTION
At some zoom levels, inline code snippets with links showed a partial underline.
With this PR, the underline won't show at any zoom level.

![image](https://user-images.githubusercontent.com/49727155/129189772-4c6cbefc-b974-4dc0-8421-d2ea76518ee8.png)
![image](https://user-images.githubusercontent.com/49727155/129189869-eed1e646-226f-444e-86b3-f330d68f7309.png)
