### PR TITLE
Miscellaneous changes to MarbleRun documentation 

### DIFF
--- a/marblerun/building-services/graphene.md
+++ b/marblerun/building-services/graphene.md
@@ -25,7 +25,7 @@ After the premain is done running, it will automatically spawn your application.
 ### Host environment variables
 The premain needs access to some host [environment variables for configuration](workflows/add-service.md#step-3-start-your-service):
 ```toml
-loader.insecure__use_host_env = 1
+loader.insecure__use_host_env = true
 ```
 The premain will remove all other variables before the actual application is launched, but there may still be risks. Don't use this on production until [secure forwarding of host environment variables](https://github.com/oscarlab/graphene/issues/2356) will be available.
 
@@ -38,7 +38,7 @@ sgx.allowed_files.uuid = "file:uuid"
 ### Remote attestation
 The Marble will send an SGX quote to the Coordinator for remote attestation:
 ```toml
-sgx.remote_attestation = 1
+sgx.remote_attestation = true
 ```
 
 ### Enclave size and threads

--- a/marblerun/building-services/graphene.md
+++ b/marblerun/building-services/graphene.md
@@ -22,8 +22,6 @@ loader.argv0_override = "hello"
 ```
 After the premain is done running, it will automatically spawn your application.
 
-For a better illustration of the differences between the two premain variants, check out our ["Hello World" sample on GitHub.](https://github.com/edgelesssys/marblerun/tree/master/samples/graphene-hello)
-
 ### Host environment variables
 The premain needs access to some host [environment variables for configuration](workflows/add-service.md#step-3-start-your-service):
 ```toml

--- a/marblerun/workflows/recover-coordinator.md
+++ b/marblerun/workflows/recover-coordinator.md
@@ -4,12 +4,14 @@ As described in the [recovery chapter](features/recovery.md), different situatio
 If the Coordinator finds a sealed state during its startup which it is unable to unseal using the host-specific SGX sealing key, it will wait for further instructions.
 You have two options:
 
-1. Recover the sealed state by uploading the recovery secret, which was encrypted for the `RecoveryKeys` defined in the manifest
+1. Recover the sealed state by uploading the recovery secret, which was encrypted for the `RecoveryKeys` defined in the manifest.
+
+    !> If no `RecoveryKeys` were defined in the manifest, recovery cannot be performed.
 
     The recovery secret can be uploaded through the `/recover` client API endpoint. To do so, you need to:
 
     * Get the temporary root certificate (valid only during recovery mode)
-    * Decode the Base64 encoded output that was returned to you during the upload of the manifest
+    * Decode the Base64 encoded output that was returned to you during the initial upload of the manifest
     * Decrypt the decoded output with the corresponding RSA private key of the key defined in the manifest
     * Upload the binary decoded and decrypted key to the `/recover` endpoint
 

--- a/marblerun/workflows/recover-coordinator.md
+++ b/marblerun/workflows/recover-coordinator.md
@@ -2,11 +2,12 @@
 
 As described in the [recovery chapter](features/recovery.md), different situations can require the *recovery* of the Coordinator.
 If the Coordinator finds a sealed state during its startup which it is unable to unseal using the host-specific SGX sealing key, it will wait for further instructions.
+
+!> You will need the corresponding private key to the `RecoveryKeys` which were defined in the manifest, and you will need the recovery secret that was returned to you during the initial upload of the manifest. If either or both of these are not available to you, recovery cannot be performed.
+
 You have two options:
 
 1. Recover the sealed state by uploading the recovery secret, which was encrypted for the `RecoveryKeys` defined in the manifest.
-
-    !> If no `RecoveryKeys` were defined in the manifest, recovery cannot be performed.
 
     The recovery secret can be uploaded through the `/recover` client API endpoint. To do so, you need to:
 


### PR DESCRIPTION
More changes from https://github.com/edgelesssys/marblerun/issues/213.

The Graphene changes (1 -> true) require a newer version than we use in our samples (at least I think...), but we should get to updating them soon anyway. On the same page, we can also incorporate the `tmpfs` suggestion for the nginx sample. I think we should do that at a later point (hopefully when v1.2-rc2 is released...)

The recovery steps are incorporated from the recent EdgelessDB documentation, I think they should be a bit more explanatory than the one we currently can find in the MarbleRun documentation. 

