### PR TITLE
AB#1175 Update auto-injection docs

### DIFF
--- a/marblerun/deployment/kubernetes.md
+++ b/marblerun/deployment/kubernetes.md
@@ -51,15 +51,19 @@ spec:
         command: <exec>
         resources:
           limits:
-            sgx.intel.com/epc: 10
+            sgx.intel.com/epc: 10Mi
+            sgx.intel.com/enclave: 1
+            sgx.intel.com/provision: 1
 ```
 
 Note, that every plugin uses its own way of injecting SGX resources into deployments. Please refer to the documentation for your plugin of choice. This is an example of the Intel plugin.
 
 MarbleRun supports [automatic injection](features/auto-injection.md) of those values for a selection of popular plugins:
 
-* [Intel](https://intel.github.io/intel-device-plugins-for-kubernetes/cmd/sgx_plugin/README.html) using `sgx.intel.com/epc`
+* [Intel](https://intel.github.io/intel-device-plugins-for-kubernetes/cmd/sgx_plugin/README.html) using `sgx.intel.com/epc`, `sgx.intel.com/enclave`, and `sgx.intel.com/provision`
 * [Azure](https://github.com/Azure/aks-engine/blob/master/docs/topics/sgx.md#deploying-the-sgx-device-plugin) using `kubernetes.azure.com/sgx_epc_mem_in_MiB`
+* [Alibaba Cloud](https://github.com/AliyunContainerService/sgx-device-plugin) using `alibabacloud.com/sgx_epc_MiB`
+* You can use the `--resource-key` flag, during installation with the CLI, to declare your own SGX resource key for injection
 
 ?> If you are using a different plugin please let us know, so we can add support!
 

--- a/marblerun/features/auto-injection.md
+++ b/marblerun/features/auto-injection.md
@@ -10,12 +10,12 @@ You can enable auto-injection of the data-plane configuration for a namespace us
 marblerun namespace add NAMESPACE [--no-sgx-injection]
 ```
 
-This will add the label `marblerun/inject=enabled` to the chosen namespace and allow the admission webhook to intercept the creation of deployments, pods, etc. in that namespace.
-The flag `--no-sgx-injection` disables the label `marblerun/inject-sgx`. This is useful when using your own SGX device plugin.
+This will add the labels `marblerun/inject=enabled` and `marblerun/inject-sgx=enabled` to the chosen namespace and allow the admission webhook to intercept the creation of deployments, pods, etc. in that namespace.
+Use the `--no-sgx-injection` flag to set the label `marblerun/inject-sgx` to `disabled`, preventing injection of SGX resources. This is useful when using your own SGX device plugin, or if you want to set the resources yourself.
 
 ## The Marbletype label
 
-In MarbleRun, marbles (i.e, secure enclaves) are defined in the [manifest](workflows/define-manifest.md). You need to reference marbles in your Kubernetes resource description as follows using the `marblerun/marbletype` label:
+In MarbleRun, Marbles (i.e, secure enclaves) are defined in the [manifest](workflows/define-manifest.md). You need to reference Marbles in your Kubernetes resource description as follows using the `marblerun/marbletype` label:
 
 ```javascript
 {
@@ -39,9 +39,14 @@ metadata:
 
 We use this label to map Kubernetes Pods to MarbleRun Marbles.
 When you deploy your application, MarbleRun will read out this label's value, `voting-svc` in the example above.
-It will check the Marbles section of your manifest for an entry with the same name.
-If such entry is present in the manifest, the Pod is provided with the particular configuration for this Marble.
-If no such entry exists or a valid `marblerun/marbletype` label is missing, the Pod's creation is rejected.
+It will then inject environment variables and SGX resources into the containers of the Pod.
+If the `marblerun/marbletype` label is missing, the Pod's injection is skipped.
+
+## The Marblecontainer label
+
+By default MarbleRun will inject environment variables and resource requests into all containers of the Pod.
+You can use the `marblerun/marblecontainer=<ContainerName>` label to limit injection to the specified container.
+This is useful if your configuration uses multiple containers in the same Pod, e.g. a sidecar proxy, and you wish to prevent non enclave containers taking up resources.
 
 ## Injected environment variables
 


### PR DESCRIPTION
### Proposed changes
* Use the correct Intel SGX resources in the Kubernetes example
* Corrected mention of the webhook rejecting pods if the `marblerun/marbletype` label is not set. If it is not set, the Pod can start, but no injection is performed
* Corrected mention of the webhook rejecting pods if the `marblerun/marbletype` label contained the name of a Marble not declared in the manifest. The webhook has no knowledge of the manifest. Therefore can not be used to rejected/accept request based on it
* Add support for Alibaba Cloud SGX plugin
* Add support for generic plugins by using the `--resource-key` flag
* Add `marblerun/marblecontainer` label to support injecting only a single container


### Additional info
* Relevant PR in the MarbleRun repo: https://github.com/edgelesssys/marblerun/pull/242