### PR TITLE
AB#1168 snake_case->camelCase

### DIFF
--- a/marblerun/building-services/graphene.md
+++ b/marblerun/building-services/graphene.md
@@ -60,8 +60,8 @@ You can specify the files' content in the MarbleRun manifest:
 ...
     "Parameters": {
         "Files": {
-            "/secrets/server.crt": "{{ pem .Secrets.server_cert.Cert }}",
-            "/secrets/server.key": "{{ pem .Secrets.server_cert.Private }}"
+            "/secrets/server.crt": "{{ pem .Secrets.serverCert.Cert }}",
+            "/secrets/server.key": "{{ pem .Secrets.serverCert.Private }}"
         }
     }
 ...

--- a/marblerun/reference/cli.md
+++ b/marblerun/reference/cli.md
@@ -406,8 +406,8 @@ These flags apply to all subcommands of manifest
   Successfully verified Coordinator, now requesting update log
   Update log:
   {"time":"2021-07-01T09:10:23.128Z","update":"initial manifest set"}
-  {"time":"2021-07-01T09:32:54.207Z","update":"secret set","user":"admin","secret":"symmetric_key_unset","type":"symmetric-key"}
-  {"time":"2021-07-01T09:32:54.207Z","update":"secret set","user":"admin","secret":"cert_unset","type":"cert-ed25519"}
+  {"time":"2021-07-01T09:32:54.207Z","update":"secret set","user":"admin","secret":"symmetricKeyUnset","type":"symmetric-key"}
+  {"time":"2021-07-01T09:32:54.207Z","update":"secret set","user":"admin","secret":"certUnset","type":"cert-ed25519"}
   {"time":"2021-07-01T10:05:44.791Z","update":"SecurityVersion increased","user":"admin","package":"world","new version":4}
   ```
 
@@ -585,7 +585,7 @@ marblerun recover <recovery_key_decrypted> <IP:PORT> [flags]
 **Examples**
 
 ```bash
-marblerun recover $MARBLERUN recovery_key_decrypted --era-config=era.json
+marblerun recover recovery_key_decrypted $MARBLERUN --era-config=era.json
 ```
 
 The output is similar to the following:
@@ -629,17 +629,17 @@ These flags apply to all `secret` subcommands
   **Examples**
 
   ```bash
-  marblerun secret get generic_secret symmetric_key_shared $MARBLERUN -c admin.crt -k admin.key
+  marblerun secret get genericSecret symmetricKeyShared $MARBLERUN -c admin.crt -k admin.key
   ```
 
   The output is similar to the following:
 
   ```
-  generic_secret:
+  genericSecret:
   	Type:          plain
   	Data:          SGVsbG8gZnJvbSB0aGUgTWFyYmxlcnVuIERvY3MhCg==
 
-  symmetric_key_shared:
+  symmetricKeyShared:
   	Type:          symmetric-key
   	UserDefined:   false
   	Size:          128
@@ -671,7 +671,7 @@ These flags apply to all `secret` subcommands
   ```
 
   ```bash
-  marblerun secret set certificate.pem $MARBLERUN -c admin.crt -k admin.key --from-pem certificate_secret
+  marblerun secret set certificate.pem $MARBLERUN -c admin.crt -k admin.key --from-pem certificateSecret
   ```
 
   The output is the following:

--- a/marblerun/workflows/define-manifest.md
+++ b/marblerun/workflows/define-manifest.md
@@ -48,7 +48,7 @@ Marbles represent the actual services in your mesh. They are defined in the `Mar
 {
     // ...
     "Marbles": {
-        "backend_first": {
+        "backendFirst": {
             "Package": "backend",
             "MaxActivations": 1,
             "Parameters": {
@@ -74,7 +74,7 @@ Marbles represent the actual services in your mesh. They are defined in the `Mar
                 ]
             },
             "TLS": [
-                "backend_first_tls"
+                "backendFirstTLS"
             ]
         },
         "frontend": {
@@ -88,7 +88,7 @@ Marbles represent the actual services in your mesh. They are defined in the `Mar
                 }
             },
             "TLS": [
-                "frontend_tls_1", "frontend_tls_2"
+                "frontendTLS1", "frontendTLS2"
             ]
         }
     }
@@ -166,12 +166,12 @@ In the [previous section](#manifestmarbles), we discussed how certain cryptograp
 {
     //...
     "Secrets": {
-        "secret_aes_key": {
+        "secretAESKey": {
             "Type": "symmetric-key",
             "Size": 128,
             "Shared": true
         },
-        "rsa_cert": {
+        "rsaCert": {
             "Type": "cert-rsa",
             "Size": 2048,
             "Shared": false,
@@ -182,7 +182,7 @@ In the [previous section](#manifestmarbles), we discussed how certain cryptograp
                 }
             }
         },
-        "secret_key_unset": {
+        "secretKeyUnset": {
             "Type": "symmetric-key",
             "Size": 128,
             "UserDefined": true
@@ -274,10 +274,10 @@ Refer to the [previous section](#manifestmarbles) for a list of supported encodi
 
 The following gives some examples.
 
-* Inject the certificate of custom secret `rsa_cert` in PEM format: `{{ pem .Secrets.rsa_cert.Cert }}`
-* Inject the corresponding private key in PKCS#8 format: `{{ raw .Secrets.rsa_cert.Private }}`
-* Inject the corresponding public key PKIX-encoded and in PEM format: `{{ pem .Secrets.rsa_cert.Public }}`
-* Inject a symmetric key in hex format: `{{ hex .Secrets.secret_aes_key }}`
+* Inject the certificate of custom secret `rsaCert` in PEM format: `{{ pem .Secrets.rsaCert.Cert }}`
+* Inject the corresponding private key in PKCS#8 format: `{{ raw .Secrets.rsaCert.Private }}`
+* Inject the corresponding public key PKIX-encoded and in PEM format: `{{ pem .Secrets.rsaCert.Public }}`
+* Inject a symmetric key in hex format: `{{ hex .Secrets.secretAESKey }}`
 
 ## Users
 The optional entry `Users` defines user credentials and role bindings for authentication and access control.
@@ -291,15 +291,15 @@ Users with the appropriate roles can [update a manifest](workflows/update-manife
         "alice": {
             "Certificate": "-----BEGIN CERTIFICATE-----\nMIIFPjCCA...",
             "Roles": [
-                "secret_manager",
-                "update_frontend"
+                "secretManager",
+                "updateFrontend"
             ]
         },
         "bob": {
             "Certificate": "-----BEGIN CERTIFICATE-----\nMIIFP...",
             "Roles": [
-                "secret_manager",
-                "update_backend"
+                "secretManager",
+                "updateBackend"
             ]
         }
     }
@@ -332,21 +332,21 @@ Valid `Actions` are:
 {
     //...
     "Roles": {
-        "update_frontend": {
+        "updateFrontend": {
             "ResourceType": "Packages",
             "ResourceNames": ["frontend"],
             "Actions": ["UpdateSecurityVersion"]
         },
-        "update_backend": {
+        "updateBackend": {
             "ResourceType": "Packages",
             "ResourceNames": ["backend"],
             "Actions": ["UpdateSecurityVersion"]
         },
-        "secret_manager": {
+        "secretManager": {
             "ResourceType": "Secrets",
             "ResourceNames": [
-                "secret_key_unset",
-                "generic_secret"
+                "secretKeyUnset",
+                "genericSecret"
             ],
             "Actions": [
                 "ReadSecret",
@@ -404,7 +404,7 @@ Incoming connections are defined by `Port`. For services used by external client
     //...
     "TLS":
     {
-        "frontend_tls_1": {
+        "frontendTLS1": {
             "Outgoing": [
                 {
                     "Port": "8080",
@@ -421,12 +421,12 @@ Incoming connections are defined by `Port`. For services used by external client
                 },
                 {
                     "Port": "8080",
-                    "Cert": "rsa_cert",
+                    "Cert": "rsaCert",
                     "DisableClientAuth": true
                 }
             ]
         },
-        "backend_first_tls": {
+        "backendFirstTLS": {
             // ...
         }
     }

--- a/marblerun/workflows/managing-secrets.md
+++ b/marblerun/workflows/managing-secrets.md
@@ -13,13 +13,13 @@ Similarly, predefined users can retrieve particular secrets from the Coordinator
 
 Authorized users can use the client API to read secrets in JSON format.
 
-For example, the following command requests a secret named `symmetric_key_shared`:
+For example, the following command requests a secret named `symmetricKeyShared`:
 ```bash
-marblerun secret get symmetric_key_shared $MARBLERUN --cert=admin-cert.pem --key=admin-key.pem --era-config=era.json
+marblerun secret get symmetricKeyShared $MARBLERUN --cert=admin-cert.pem --key=admin-key.pem --era-config=era.json
 ```
 If the user has the required permissions, the secret is returned:
 ```
-symmetric_key_shared:
+symmetricKeyShared:
 	Type:          symmetric-key
 	UserDefined:   false
 	Size:          128
@@ -68,18 +68,18 @@ Each entry in the file is a JSON object labeled by the name of the secret and co
 * For the type `plain`:
   * `Key`: arbitrary data in base64 encoding. This may be a key of unspecified length, a confidential config file, or any kind of data only some Marbles and/or users should have access to.
 
-The following gives an example for a file to set the secrets `user_defined_symmetric_key`, `user_defined_cert`, and `generic_secret`:
+The following gives an example for a file to set the secrets `userDefinedSymmetricKey`, `userDefinedCert`, and `genericSecret`:
 
 ```javascript
 {
-  "user_defined_symmetric_key": {
+  "userDefinedSymmetricKey": {
     "Key": "AAECAwQFBgcICQoLDA0ODw=="
   },
-  "user_defined_cert": {
+  "userDefinedCert": {
     "Cert": "MIIBjDCCATOgAwIBAgICBTkwCgYIKoZIzj0EAwIwMjEwMC4GA1UEAxMnTWFyYmxlcnVuIENvb3JkaW5hdG9yIC0gSW50ZXJtZWRpYXRlIENBMB4XDTIxMDYxNTA4NTY0M1oXDTIxMDYyMjA4NTY0M1owLTEcMBoGA1UEAxMTTWFyYmxlcnVuIFVuaXQgVGVzdDENMAsGA1UEBRMEMTMzNzAqMAUGAytlcAMhAEPOc066G5XmvLizOKTENSR+U9lv3geZ0/a2+XkhJRvDo20wazAOBgNVHQ8BAf8EBAMCAoQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwLAYDVR0RBCUwI4IJbG9jYWxob3N0hwR/AAABhxAAAAAAAAAAAAAAAAAAAAABMAoGCCqGSM49BAMCA0cAMEQCIGOlRcynaPaj/flSr2ZEvmTmhuvtmTb4QkwPFtxFz3EJAiB77ijxAcJNxPKcKmgMB+c8NORC+6N/St2iP/oX/vqQvg==",
     "Private": "MC4CAQAwBQYDK2VwBCIEIPlmAOOhAStk8ytxzvekPr8zLaQa9+lxnHK+CizDrMds"
   },
-  "generic_secret": {
+  "genericSecret": {
     "Key": "SGVsbG8gZnJvbSB0aGUgTWFyYmxlcnVuIERvY3MhCg=="
   }
 }

--- a/marblerun/workflows/recover-coordinator.md
+++ b/marblerun/workflows/recover-coordinator.md
@@ -27,7 +27,7 @@ You have two options:
     The extracted secret can then be uploaded using the MarbleRun CLI.
 
     ```bash
-    marblerun recover $MARBLERUN recovery_key_decrypted
+    marblerun recover recovery_key_decrypted $MARBLERUN
     ```
 
     Alternatively, you can use `curl`:


### PR DESCRIPTION
Continuation of https://github.com/edgelesssys/marblerun/pull/243
Updated snake_case in references to the MarbleRun manifest where applicable to camelCase.

Instances not changed include:
* file names
* placeholder names in samples other than the MarbleRun manifests (k8s files, cli reference etc.)

Once again there where some changes to swagger files, let me know if anything broke.
If you notice any leftover snake_case instances, feel free to add to this PR

Also fixed the order of arguments for `marblerun recover` in the CLI reference and recovery section