### PR TITLE
Ref/ego/ego install

### DIFF
--- a/ego/getting-started/troubleshoot.md
+++ b/ego/getting-started/troubleshoot.md
@@ -27,26 +27,15 @@ ls /dev/*sgx*
 ```
 If the output is empty, install the driver.
 
-If your system supports FLC (see above):
+The easiest way to install the driver is using ego install:
 ```bash
-wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu`lsb_release -rs`-server/sgx_linux_x64_driver_1.36.2.bin
-chmod +x sgx_linux_x64_driver_1.36.2.bin
-sudo ./sgx_linux_x64_driver_1.36.2.bin
-```
-
-Otherwise:
-```bash
-wget https://download.01.org/intel-sgx/sgx-linux/2.13.3/distro/ubuntu`lsb_release -rs`-server/sgx_linux_x64_driver_2.11.0_2d2b795.bin
-chmod +x sgx_linux_x64_driver_2.11.0_2d2b795.bin
-sudo ./sgx_linux_x64_driver_2.11.0_2d2b795.bin
+ego install sgx-driver
 ```
 
 ### Required packages
 If your system doesn't support FLC, install the `libsgx-launch` package:
 ```bash
-wget -qO- https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add
-sudo add-apt-repository "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu `lsb_release -cs` main"
-sudo apt install libsgx-launch
+ego install libsgx-launch
 ```
 
 ## Attestation

--- a/ego/getting-started/troubleshoot.md
+++ b/ego/getting-started/troubleshoot.md
@@ -29,13 +29,37 @@ If the output is empty, install the driver.
 
 The easiest way to install the driver is using ego install:
 ```bash
-ego install sgx-driver
+sudo ego install sgx-driver
+```
+
+
+As an  alternative way you can install it manually. 
+
+If your system supports FLC (see above):
+```bash
+wget https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu`lsb_release -rs`-server/sgx_linux_x64_driver_1.36.2.bin
+chmod +x sgx_linux_x64_driver_1.36.2.bin
+sudo ./sgx_linux_x64_driver_1.36.2.bin
+```
+
+Otherwise:
+```bash
+wget https://download.01.org/intel-sgx/sgx-linux/2.13.3/distro/ubuntu`lsb_release -rs`-server/sgx_linux_x64_driver_2.11.0_2d2b795.bin
+chmod +x sgx_linux_x64_driver_2.11.0_2d2b795.bin
+sudo ./sgx_linux_x64_driver_2.11.0_2d2b795.bin
 ```
 
 ### Required packages
 If your system doesn't support FLC, install the `libsgx-launch` package:
 ```bash
-ego install libsgx-launch
+sudo ego install libsgx-launch
+```
+
+Or manually:
+```bash
+wget -qO- https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add
+sudo add-apt-repository "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu `lsb_release -cs` main"
+sudo apt install libsgx-launch
 ```
 
 ## Attestation

--- a/ego/reference/cli.md
+++ b/ego/reference/cli.md
@@ -83,6 +83,7 @@ to build a Go project that uses a Makefile.
 
 ## install
 Install drivers and other components.
+
 Use "ego install" to list the available components for your system. Then install the component you want.
 ```
 ego install

--- a/ego/reference/cli.md
+++ b/ego/reference/cli.md
@@ -84,7 +84,7 @@ to build a Go project that uses a Makefile.
 ## install
 Install drivers and other components.
 
-Use "ego install" to list the available components for your system. Then install the component you want.
+Use `ego install` to list the available components for your system. Then install the component you want.
 ```
 ego install
 ego install <component>

--- a/ego/reference/cli.md
+++ b/ego/reference/cli.md
@@ -80,3 +80,11 @@ For example, run
 ego env make
 ```
 to build a Go project that uses a Makefile.
+
+## install
+Install drivers and other components.
+Use "ego install" to list the available components for your system. Then install the component you want.
+```
+ego install
+ego install <component>
+```

--- a/ego/reference/quoteprov.md
+++ b/ego/reference/quoteprov.md
@@ -4,7 +4,7 @@ For remote attestation, both the attester and the verifier expect a *quote provi
 ## Azure
 Install the Azure DCAP client:
 ```bash
-ego install az-dcap-client
+sudo ego install az-dcap-client
 ```
 
 ## On-premises or other cloud

--- a/ego/reference/quoteprov.md
+++ b/ego/reference/quoteprov.md
@@ -6,6 +6,12 @@ Install the Azure DCAP client:
 ```bash
 sudo ego install az-dcap-client
 ```
+Or manually:
+```bash
+wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add
+sudo add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/ubuntu/`lsb_release -rs`/prod `lsb_release -cs` main"
+sudo apt install az-dcap-client
+```
 
 ## On-premises or other cloud
 If the enclave app runs on-premises or on another cloud that doesn't provide its own attestation infrastructure, follow the [guide from Open Enclave](https://github.com/openenclave/openenclave/blob/master/docs/GettingStartedDocs/Contributors/NonAccMachineSGXLinuxGettingStarted.md#3-set-up-intel-dcap-quote-provider-library-qpl) to set up the required services.

--- a/ego/reference/quoteprov.md
+++ b/ego/reference/quoteprov.md
@@ -4,9 +4,7 @@ For remote attestation, both the attester and the verifier expect a *quote provi
 ## Azure
 Install the Azure DCAP client:
 ```bash
-wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add
-sudo add-apt-repository "deb [arch=amd64] https://packages.microsoft.com/ubuntu/`lsb_release -rs`/prod `lsb_release -cs` main"
-sudo apt install az-dcap-client
+ego install az-dcap-client
 ```
 
 ## On-premises or other cloud


### PR DESCRIPTION
Since components like sgx-driver and libsgx-launch can now be installed using the install command, I removed the instructions containing several steps and replaced them with the short ego install <component> form. I also added a description for the install command in the cli.md