### PR TITLE
Update quickstart-azure.md

### DIFF
--- a/edgelessdb/getting-started/quickstart-azure.md
+++ b/edgelessdb/getting-started/quickstart-azure.md
@@ -72,7 +72,7 @@ Here, `edgelessdb-sgx.json` contains the expected properties of your EdgelessDB 
 ## Set the manifest
 You're now ready to send the manifest over a secure TLS connection based on the attested root certificate of your EdgelessDB instance:
 ```bash
-curl --cacert edb.pem --data-binary @manifest.json https://<your-azure-ip>:8080/manifest
+curl --cacert edb.pem --data-binary @manifest.json --resolve edb:8080:<your-azure-ip> https://edb:8080/manifest
 ```
 
 In case you skipped the verification step above, just replace `--cacert edb.pem` with `-k` in the above command.


### PR DESCRIPTION
I followed the steps and got
```
$ curl --cacert edb.pem --data-binary @manifest.json https://20.108...:8080/manifest
curl: (60) SSL: no alternative certificate subject name matches target host name '20.108...'
```
With this workaround it succeeds.