### PR TITLE
AB#1317 Replace Graphene with Gramine

### DIFF
--- a/marblerun/_sidebar.md
+++ b/marblerun/_sidebar.md
@@ -30,7 +30,7 @@
     * [Recovering the Coordinator](workflows/recover-coordinator.md)
 * **Building services**
     * [EGo](building-services/ego.md)
-    * [Graphene](building-services/graphene.md)
+    * [Gramine](building-services/gramine.md)
     * [Occlum](building-services/occlum.md)
 * [**Examples**](examples.md)
 * **Reference**

--- a/marblerun/building-services/gramine.md
+++ b/marblerun/building-services/gramine.md
@@ -1,8 +1,8 @@
-# Building a service: Graphene
-Running a Graphene app with MarbleRun requires some changes to its manifest. These are explained in the following. See also the [helloworld example](https://github.com/edgelesssys/marblerun/tree/master/samples/graphene-hello).
+# Building a service: Gramine
+Running a Gramine app with MarbleRun requires some changes to its manifest. These are explained in the following. See also the [helloworld example](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-hello).
 
 ## Requirements
-First, get Graphene up and running. You can use either the [Building](https://graphene.readthedocs.io/en/latest/building.html) or [Cloud Deployment](https://graphene.readthedocs.io/en/latest/cloud-deployment.html) guide to build and initially set up Graphene.
+First, get Gramine up and running. Gramine is available [as a debian package]](https://github.com/gramineproject/gramine/releases). Alternatively you can follow either the [Building](https://gramine.readthedocs.io/en/latest/building.html) or [Cloud Deployment](https://gramine.readthedocs.io/en/latest/cloud-deployment.html) guide to build and install Gramine from source.
 
 Before running your application, make sure you got the prerequisites for ECDSA remote attestation installed on your system. You can collectively install them with the following command:
 ```sh
@@ -12,22 +12,29 @@ sudo apt install libsgx-quote-ex-dev
 ### Entrypoint and argv
 We provide the `premain-libos` executable with the [MarbleRun Releases](https://github.com/edgelesssys/marblerun/releases). It will contact the Coordinator, set up the environment, and run the actual application.
 
-Set the premain executable as the entry point of the Graphene project and place the actual entry point in argv0:
+Set the premain executable as the entry point of the Gramine project and place the actual entry point in argv0:
 ```toml
 libos.entrypoint = "file:premain-libos"
-sgx.trusted_files.premain = "file:premain-libos"
 
 # argv0 needs to contain the name of your executable
 loader.argv0_override = "hello"
+
+# add the premain to the list of trusted files
+sgx.trusted_files = [
+    # ...
+    "file:premain-libos"
+]
 ```
 After the premain is done running, it will automatically spawn your application.
 
 ### Host environment variables
 The premain needs access to some host [environment variables for configuration](workflows/add-service.md#step-3-start-your-service):
 ```toml
-loader.insecure__use_host_env = true
+loader.env.EDG_MARBLE_TYPE = { passthrough = true }
+loader.env.EDG_MARBLE_COORDINATOR_ADDR = { passthrough = true }
+loader.env.EDG_MARBLE_UUID_FILE = { passthrough = true }
+loader.env.EDG_MARBLE_DNS_NAMES = { passthrough = true }
 ```
-The premain will remove all other variables before the actual application is launched, but there may still be risks. Don't use this on production until [secure forwarding of host environment variables](https://github.com/oscarlab/graphene/issues/2356) will be available.
 
 ### uuid file
 The Marble must be able to store its uuid:
@@ -50,7 +57,7 @@ sgx.thread_num = 16
 
 If your application has high memory demands, you may need to increase the size even further.
 ### Secret files
-A Marble's secrets, e.g. a certificate and private key, can be provisioned as files. You can utilize Graphene's in-memory filesystem [`tmpfs`](https://graphene.readthedocs.io/en/latest/manifest-syntax.html#fs-mount-points), so the secrets will never show up on the host's file system :
+A Marble's secrets, e.g. a certificate and private key, can be provisioned as files. You can utilize Gramine's in-memory filesystem [`tmpfs`](https://gramine.readthedocs.io/en/latest/manifest-syntax.html#fs-mount-points), so the secrets will never show up on the host's file system :
 ```toml
 fs.mount.secrets.type = "tmpfs"
 fs.mount.secrets.path = "/secrets"
@@ -67,13 +74,13 @@ You can specify the files' content in the MarbleRun manifest:
 ...
 ```
 
-Note that Graphene also allows to store files encrypted on the host's file system. The so called `protected files` require to initialize the protected files key by writing it hex-encoded to the virtual `protected_files_key` device:
+Note that Gramine also allows to store files encrypted on the host's file system. The so called `protected files` require to initialize the protected files key by writing it hex-encoded to the virtual `protected_files_key` device:
 
 ```
 sgx.protected_files_key = "[16-byte hex value]"
 sgx.protected_files.[identifier] = "[URI]"
 ```
-You can see how this key can be initializied with MarbleRun in the [nginx example](https://github.com/edgelesssys/marblerun/tree/master/samples/graphene-nginx).
+You can see how this key can be initializied with MarbleRun in the [nginx example](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-nginx).
 
 ## Troubleshooting
 ### aesm_service returned error: 30

--- a/marblerun/deployment/kubernetes.md
+++ b/marblerun/deployment/kubernetes.md
@@ -74,7 +74,7 @@ Intel SGX supports two modes for obtaining remote attestation quotes:
 * In-process: The software generating the quote is part of the enclave application
 * Out-of-process: The software generating the quote is not part of the actual enclave application. This requires the Intel SGX Architectural Enclave Service Manager (AESM) to run on the system
 
-While Marbles built with [Ego](building-services/ego.md) perform in-process attestation, other frameworks, such as [Graphene](building-services/graphene.md), use out-of-process attestation.
+While Marbles built with [Ego](building-services/ego.md) perform in-process attestation, other frameworks, such as [Gramine](building-services/gramine.md), use out-of-process attestation.
 If your confidential application uses out-of-process attestation, you will need to expose the AESM device to your container.
 
 You can follow [the AKS guide](https://docs.microsoft.com/en-us/azure/confidential-computing/confidential-nodes-out-of-proc-attestation) to make your deployments able to use AESM for quote generation. Note, that in this case, your Kubernetes nodes need the AESM service installed. See the [Intel installation guide](https://download.01.org/intel-sgx/sgx-linux/2.12/docs/Intel_SGX_Installation_Guide_Linux_2.12_Open_Source.pdf) for more information.

--- a/marblerun/deployment/standalone.md
+++ b/marblerun/deployment/standalone.md
@@ -34,7 +34,7 @@ See the [how to add a service](workflows/add-service.md) documentation for more 
 ### Run your workloads
 
 You first need to build your workloads together with our Marble data plane.
-See our guides for building [EGo](building-services/ego.md), [Graphene](building-services/graphene.md), and [Occlum](building-services/occlum.md) workloads.
+See our guides for building [EGo](building-services/ego.md), [Gramine](building-services/gramine.md), and [Occlum](building-services/occlum.md) workloads.
 
 You can then run your Marble as follows:
 

--- a/marblerun/examples.md
+++ b/marblerun/examples.md
@@ -19,10 +19,10 @@ We provide a hands-on example for a confidential multi-stakeholder inference ser
 * Check it out [on GitHub](https://github.com/edgelesssys/marblerun-tensorflow-demo)
 
 
-## Graphene-based examples
-We provide two examples for Graphene-based Marbles:
-* A [helloworld](https://github.com/edgelesssys/marblerun/tree/master/samples/graphene-hello) example to get you started. 🤓
-* An [NGINX webserver](https://github.com/edgelesssys/marblerun/tree/master/samples/graphene-nginx) for an example of converting an existing Graphene application to a Marble. :rocket:
+## Gramine-based examples
+We provide two examples for Gramine-based Marbles:
+* A [helloworld](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-hello) example to get you started. 🤓
+* An [NGINX webserver](https://github.com/edgelesssys/marblerun/tree/master/samples/gramine-nginx) for an example of converting an existing Gramine application to a Marble. :rocket:
 
 ## Occlum-based examples
 

--- a/marblerun/features/runtimes.md
+++ b/marblerun/features/runtimes.md
@@ -8,11 +8,11 @@ MarbleRun strives to be runtime-agnostic. Currently, supported runtimes are desc
 ## Edgeless RT
 With [Edgeless RT](https://github.com/edgelesssys/edgelessrt) you can create confidential C++ applications with a low TCB. Please follow the build instructions provided [in our C++ sample](https://github.com/edgelesssys/marblerun/blob/master/samples/helloc%2B%2B) to use it with MarbleRun.
 
-## Graphene
-[Graphene](https://grapheneproject.io/) is a popular choice for wrapping unmodified applications into enclaves.
+## Gramine
+[Gramine](https://gramineproject.io/) is a popular choice for wrapping unmodified applications into enclaves.
 This approach, commonly known as "lift and shift", facilitates the process of bringing existing applications into the confidential space.
-Graphene further adds support for dynamically linked libraries and multi-process applications in SGX.
-[Running a Graphene app](building-services/graphene.md) with MarbleRun requires minor changes to its manifest.
+Gramine further adds support for dynamically linked libraries and multi-process applications in SGX.
+[Running a Gramine app](building-services/gramine.md) with MarbleRun requires minor changes to its manifest.
 
 ## Occlum
 [Occlum](https://github.com/occlum/occlum) is another popular solution which allows wrapping existing applications with minimal to no changes inside an enclave, requiring you to at best recompile existing applications with the provided toolset with support for common languages such as C, C++, Go, Java and Rust.

--- a/marblerun/reference/cli.md
+++ b/marblerun/reference/cli.md
@@ -38,7 +38,7 @@ Available Commands:
   certificate      Retrieves the certificate of the MarbleRun Coordinator
   check            Check the status of MarbleRun's control plane
   completion       Output script for specified shell to enable autocompletion
-  graphene-prepare Modifies a Graphene manifest for use with MarbleRun
+  gramine-prepare  Modifies a Gramine manifest for use with MarbleRun
   help             Help about any command
   install          Installs marblerun on a kubernetes cluster
   manifest         Manages manifest for the MarbleRun Coordinator
@@ -154,34 +154,34 @@ Once enabled, command completion is just one keypress away:\
   `marblerun manifest`
 
 
-## Command `graphene-prepare`
-This command helps you if you want to add Graphene-based services to your MarbleRun service mesh.
-It prepares your Graphene project to be used as a Marble by replacing the original entrypoint of your application with the bootstrapping Marble premain process which eventually spawns your application.
-Given your [Graphene manifest template](https://graphene.readthedocs.io/en/latest/manifest-syntax.html), it will suggest the required adjustments needed and adds our bootstrapping data-plane code to your Graphene image.
-See [Building a service: Graphene](building-services/graphene.md) for detailed information on MarbleRun’s Graphene integration and our changes in your Graphene manifest.
+## Command `gramine-prepare`
+This command helps you if you want to add Gramine-based services to your MarbleRun service mesh.
+It prepares your Gramine project to be used as a Marble by replacing the original entrypoint of your application with the bootstrapping Marble premain process which eventually spawns your application.
+Given your [Gramine manifest template](https://gramine.readthedocs.io/en/latest/manifest-syntax.html), it will suggest the required adjustments needed and adds our bootstrapping data-plane code to your Gramine image.
+See [Building a service: Gramine](building-services/gramine.md) for detailed information on MarbleRun’s Gramine integration and our changes in your Gramine manifest.
 
 Please note that this only works on a best-effort basis and may not instantly work correctly.
-While suggestions should be made for every valid TOML Graphene configuration, changes can only be performed for non-hierarchically sorted configurations. as the official Graphene examples.
+While suggestions should be made for every valid TOML Gramine configuration, changes can only be performed for non-hierarchically sorted configurations. as the official Gramine examples.
 The unmodified manifest is saved as a backup under the old path with an added ".bak" suffix, allowing you to try out and roll back any changes performed.
 
-Remember, you need to create a [MarbleRun manifest](workflows/define-manifest.md) in addition to the Graphene manifest. Adding Graphene packages to your manifest is straightforward and follows the same principles as any other SGX enclave. If you configured the arguments to your Graphene application through the [Graphene manifest](https://graphene.readthedocs.io/en/latest/manifest-syntax.html#command-line-arguments) before, you need to transfer those to the [MarbleRun manifest](workflows/define-manifest.md#manifestmarbles">}}).
+Remember, you need to create a [MarbleRun manifest](workflows/define-manifest.md) in addition to the Gramine manifest. Adding Gramine packages to your manifest is straightforward and follows the same principles as any other SGX enclave. If you configured the arguments to your Gramine application through the [Gramine manifest](https://gramine.readthedocs.io/en/latest/manifest-syntax.html#command-line-arguments) before, you need to transfer those to the [MarbleRun manifest](workflows/define-manifest.md#manifestmarbles">}}).
 
   **Usage**
 
   ```bash
-  marblerun graphene-prepare <path>
+  marblerun gramine-prepare <path>
   ```
 
   **Examples**
   ```bash
-  marblerun graphene-prepare nginx.manifest.template
+  marblerun gramine-prepare nginx.manifest.template
   ```
 
   Output:
   ```bash
   Reading file: nginx.manifest.template
 
-  MarbleRun suggests the following changes to your Graphene manifest:
+  MarbleRun suggests the following changes to your Gramine manifest:
   libos.entrypoint = "file:premain-libos"
   loader.argv0_override = "$(INSTALL_DIR)/sbin/nginx"
   loader.insecure__use_host_env = 1

--- a/marblerun/workflows/add-service.md
+++ b/marblerun/workflows/add-service.md
@@ -7,7 +7,7 @@ Adding a service to your application requires three steps, which are described i
 To get your service ready for MarbleRun, you need to rebuild it with one of the supported [runtimes](features/runtimes.md):
 * [EGo](building-services/ego.md)
 * [Edgeless RT](https://github.com/edgelesssys/marblerun/blob/master/samples/helloc%2B%2B)
-* [Graphene](building-services/graphene.md)
+* [Gramine](building-services/gramine.md)
 * [Occlum](building-services/occlum.md)
 
 ### Make your service use the provided TLS credentials
@@ -46,13 +46,13 @@ The tool's output is similar to the following.
 }
 ```
 
-#### Graphene
+#### Gramine
 
-To add an entry for your Graphene service, run the `graphene-sgx-get-token` tool on the `.sig` file you built in the previous step as follows. (`graphene-sgx-get-token` is installed with [Graphene](https://github.com/oscarlab/graphene/).)
+To add an entry for your Gramine service, run the `gramine-sgx-get-token` tool on the `.sig` file you built in the previous step as follows. (`gramine-sgx-get-token` is installed with [Gramine](https://github.com/oscarlab/gramine/).)
 
 
 ```bash
-graphene-sgx-get-token --sig hello.sig
+gramine-sgx-get-token --sig hello.sig
 ```
 
 The tool's output is similar to the following.
@@ -113,7 +113,7 @@ erthost enclave.signed
 ```
 
 `erthost` is the generic host for EdgelessRT Marbles, which will load your `enclave.signed`.
-For EGo (`ego marblerun`), Graphene (`graphene-sgx`), and Occlum (`occlum run`) use their particular launch mechanism instead.
+For EGo (`ego marblerun`), Gramine (`gramine-sgx`), and Occlum (`occlum run`) use their particular launch mechanism instead.
 
 The environment variables have the following purposes.
 

--- a/marblerun/workflows/define-manifest.md
+++ b/marblerun/workflows/define-manifest.md
@@ -396,7 +396,7 @@ awk 'NF {sub(/\r/, ""); printf "%s\\n",$0;}' public_key.pem
 
 ## TLS
 
-!> The Transparent TLS feature is currently only available for EGo and Edgeless RT Marbles. Graphene and Occlum are not supported yet.
+!> The Transparent TLS feature is currently only available for EGo and Edgeless RT Marbles. Gramine and Occlum are not supported yet.
 
 The TLS entry holds a list of tags which can be used in a Marble's definition. Each tag can define multiple `Incoming` and `Outgoing` connections. To elevate the connection between two marbles to TLS, the client needs to set the server under `Outgoing` and the server needs to define its service under `Incoming`.
 


### PR DESCRIPTION
Replaces all mentions of "Graphene" with "Gramine", and update the Gramine building-services section to be in line with the latest manifest format