### PR TITLE
Add proxy for constellation

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/constellation/* https://constellation-docs.netlify.app/constellation/:splat 200!


### PR DESCRIPTION
Blocked by https://github.com/edgelesssys/constellation-docs/pull/95
Adds the proxy for Constellation with the effect that the Constellation docs are reachable via https://docs.edgeless.sytems/constellation